### PR TITLE
Adding stacktrace on error calls

### DIFF
--- a/app/initializers/rollbar.js
+++ b/app/initializers/rollbar.js
@@ -6,8 +6,11 @@ export default {
   initialize: function() {
     var errorLogger = Ember.Logger.error;
     Ember.Logger.error = function() {
+      var args = Array.prototype.slice.call(arguments),
+          err = isError(args[0]) ? args[0] : new Error(stringify(args));
+
       if (window.Rollbar) {
-        Rollbar.error.apply(Rollbar, arguments);
+        Rollbar.error.call(Rollbar, err);
       }
       errorLogger.apply(this, arguments);
     };
@@ -33,4 +36,12 @@ export default {
       debugLogger.apply(this, arguments);
     };
   }
+};
+
+var stringify = function(object){
+  return JSON ? JSON.stringify(object) : object.toString();
+};
+
+var isError = function(object){
+  return Ember.typeOf(object) === 'error';
 };


### PR DESCRIPTION
Rollbar.error accepts Error objects and displays a nice stack trace for
them. This gives the user a bit more useful information when trying to
locate an issue.
