### PR TITLE
Make Ember.Logger.error an alias to Rollbar.error

### DIFF
--- a/app/initializers/rollbar.js
+++ b/app/initializers/rollbar.js
@@ -6,11 +6,8 @@ export default {
   initialize: function() {
     var errorLogger = Ember.Logger.error;
     Ember.Logger.error = function() {
-      var args = Array.prototype.slice.call(arguments),
-          err = isError(args[0]) ? args[0] : new Error(stringify(args));
-
       if (window.Rollbar) {
-        Rollbar.error.call(Rollbar, err);
+        Rollbar.error.apply(Rollbar, arguments);
       }
       errorLogger.apply(this, arguments);
     };
@@ -36,12 +33,4 @@ export default {
       debugLogger.apply(this, arguments);
     };
   }
-};
-
-var stringify = function(object){
-  return JSON ? JSON.stringify(object) : object.toString();
-};
-
-var isError = function(object){
-  return Ember.typeOf(object) === 'error';
 };

--- a/app/initializers/rollbar.js
+++ b/app/initializers/rollbar.js
@@ -3,34 +3,34 @@ import Ember from 'ember';
 
 export default {
   name: 'rollbar',
-  initialize: function() {
-    var errorLogger = Ember.Logger.error;
+  initialize() {
+    let errorLogger = Ember.Logger.error;
     Ember.Logger.error = function() {
       if (window.Rollbar) {
-        Rollbar.error.apply(Rollbar, arguments);
+        Rollbar.error(...arguments);
       }
-      errorLogger.apply(this, arguments);
+      errorLogger(...arguments);
     };
-    var warnLogger = Ember.Logger.warn;
+    let warnLogger = Ember.Logger.warn;
     Ember.Logger.warn = function() {
       if (window.Rollbar) {
-        Rollbar.warning.apply(Rollbar, arguments);
+        Rollbar.warning(...arguments);
       }
-      warnLogger.apply(this, arguments);
+      warnLogger(...arguments);
     };
-    var infoLogger = Ember.Logger.info;
+    let infoLogger = Ember.Logger.info;
     Ember.Logger.info = function() {
       if (window.Rollbar) {
-        Rollbar.info.apply(Rollbar, arguments);
+        Rollbar.info(...arguments);
       }
-      infoLogger.apply(this, arguments);
+      infoLogger(...arguments);
     };
-    var debugLogger = Ember.Logger.debug;
+    let debugLogger = Ember.Logger.debug;
     Ember.Logger.debug = function() {
       if (window.Rollbar) {
-        Rollbar.debug.apply(Rollbar, arguments);
+        Rollbar.debug(...arguments);
       }
-      debugLogger.apply(this, arguments);
+      debugLogger(...arguments);
     };
   }
 };

--- a/index.js
+++ b/index.js
@@ -1,30 +1,30 @@
 /* jshint node: true */
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var merge = require('lodash/object/merge');
-var template = require('lodash/string/template');
+let fs = require('fs');
+let path = require('path');
+let merge = require('lodash/object/merge');
+let template = require('lodash/string/template');
 
 module.exports = {
   name: 'ember-cli-rollbar',
   contentFor: function(type, config) {
-    var environment = this.app.env;
+    let environment = this.app.env;
     config = config.rollbar || {};
-    var isProductionEnv = ['development', 'test'].indexOf(environment) === -1;
-    var includeScript = isProductionEnv || config.enabled;
+    let isProductionEnv = ['development', 'test'].indexOf(environment) === -1;
+    let includeScript = isProductionEnv || config.enabled;
     if (type === 'head' && includeScript) {
-      var rollbarConfig = merge({
+      let rollbarConfig = merge({
         enabled: isProductionEnv,
         captureUncaught: true,
         payload: {
           environment: environment
         }
       }, config);
-      var htmlPath = path.join(__dirname, 'addon', 'rollbar.html');
-      var htmlContent = fs.readFileSync(htmlPath, 'utf-8');
-      var snippetPath = path.join(__dirname, 'addon', 'snippet.js');
-      var snippetContent = fs.readFileSync(snippetPath, 'utf-8');
+      let htmlPath = path.join(__dirname, 'addon', 'rollbar.html');
+      let htmlContent = fs.readFileSync(htmlPath, 'utf-8');
+      let snippetPath = path.join(__dirname, 'addon', 'snippet.js');
+      let snippetContent = fs.readFileSync(snippetPath, 'utf-8');
       return template(htmlContent)({
         rollbarConfig: JSON.stringify(rollbarConfig),
         rollbarSnippet: snippetContent


### PR DESCRIPTION
Removes the logic created in #2.

We can now call `Ember.Logger.error` the way we would call `Rollbar.error`.

It still allows to pass the error and to have the stacktraces (which was the claim of #2 from what I understand). It also allows to pass extra JSON objects to Rollbar (which is very useful) as a third parameter (just as you can do with `Rollbar.error`), whereas this feature was removed by #2.

Here are examples of usage:

``` javascript
Ember.Logger.error("Error message");
```

``` javascript
Ember.Logger.error(error);
```

``` javascript
Ember.Logger.error("Error message", error, {a: 1, b:2});
```

``` javascript
Ember.Logger.error(error, {a: 1, b:2});
```

see more [in the official Rollbar documentation](https://rollbar.com/docs/notifier/rollbar.js/).
