### PR TITLE
rollbar initializer now checks if config.rollbar.enabled == true

### DIFF
--- a/app/initializers/rollbar.js
+++ b/app/initializers/rollbar.js
@@ -4,6 +4,14 @@ import Ember from 'ember';
 export default {
   name: 'rollbar',
   initialize: function() {
+    var config = getConfigEnvrionment();
+    var rollbarEnabled = false;
+    try {
+      rollbarEnabled = config.rollbar.enabled;
+    } catch (e) {}
+
+    if (typeof Rollbar === 'undefined' && !rollbarEnabled) { return; }
+
     var errorLogger = Ember.Logger.error;
     Ember.Logger.error = function() {
       var args = Array.prototype.slice.call(arguments),
@@ -44,4 +52,14 @@ var stringify = function(object){
 
 var isError = function(object){
   return Ember.typeOf(object) === 'error';
+};
+
+var getConfigEnvrionment = function() {
+  if (document && window) {
+    var meta = document.querySelector('meta[name$="config/environment"');
+    if (meta && meta.content) {
+      return JSON.parse(decodeURIComponent(meta.content));
+    }
+  }
+  return null;
 };


### PR DESCRIPTION
This commit make it so Ember.Logger functions will not be intercepted if environment.rollbar.enabled is false.
