### PR TITLE
Wrap initializer in fastboot check

### DIFF
--- a/app/initializers/rollbar.js
+++ b/app/initializers/rollbar.js
@@ -4,37 +4,39 @@ import Ember from 'ember';
 export default {
   name: 'rollbar',
   initialize: function() {
-    var errorLogger = Ember.Logger.error;
-    Ember.Logger.error = function() {
-      var args = Array.prototype.slice.call(arguments),
+    if (typeof FastBoot === 'undefined') {
+      var errorLogger = Ember.Logger.error;
+      Ember.Logger.error = function() {
+        var args = Array.prototype.slice.call(arguments),
           err = isError(args[0]) ? args[0] : new Error(stringify(args));
 
-      if (window.Rollbar) {
-        Rollbar.error.call(Rollbar, err);
-      }
-      errorLogger.apply(this, arguments);
-    };
-    var warnLogger = Ember.Logger.warn;
-    Ember.Logger.warn = function() {
-      if (window.Rollbar) {
-        Rollbar.warning.apply(Rollbar, arguments);
-      }
-      warnLogger.apply(this, arguments);
-    };
-    var infoLogger = Ember.Logger.info;
-    Ember.Logger.info = function() {
-      if (window.Rollbar) {
-        Rollbar.info.apply(Rollbar, arguments);
-      }
-      infoLogger.apply(this, arguments);
-    };
-    var debugLogger = Ember.Logger.debug;
-    Ember.Logger.debug = function() {
-      if (window.Rollbar) {
-        Rollbar.debug.apply(Rollbar, arguments);
-      }
-      debugLogger.apply(this, arguments);
-    };
+        if (window.Rollbar) {
+          Rollbar.error.call(Rollbar, err);
+        }
+        errorLogger.apply(this, arguments);
+      };
+      var warnLogger = Ember.Logger.warn;
+      Ember.Logger.warn = function() {
+        if (window.Rollbar) {
+          Rollbar.warning.apply(Rollbar, arguments);
+        }
+        warnLogger.apply(this, arguments);
+      };
+      var infoLogger = Ember.Logger.info;
+      Ember.Logger.info = function() {
+        if (window.Rollbar) {
+          Rollbar.info.apply(Rollbar, arguments);
+        }
+        infoLogger.apply(this, arguments);
+      };
+      var debugLogger = Ember.Logger.debug;
+      Ember.Logger.debug = function() {
+        if (window.Rollbar) {
+          Rollbar.debug.apply(Rollbar, arguments);
+        }
+        debugLogger.apply(this, arguments);
+      };
+    }
   }
 };
 


### PR DESCRIPTION
Currently if you try to use this add-on with an app that has Fastboot enabled it will throw an error and refuse to render anything due to the use of `document`. One of the suggested updates to support Fastboot, specifically for initializers, is to wrap them in a check for the existance of Fastboot.

While there is likely further work to be done to support Fastboot, I think this is a good first step.